### PR TITLE
fix: ignore mongoose vuln

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.10.2
+version: v1.12.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   'npm:node-uuid:20160328':
@@ -38,6 +38,10 @@ ignore:
         reason: None given
         expires: '2100-01-01T00:00:00.000Z'
     - mongoose > mongodb > mongodb-core > bson:
+        reason: None given
+        expires: '2100-01-01T00:00:00.000Z'
+  SNYK-JS-MPATH-72672:
+    - mongoose > mpath:
         reason: None given
         expires: '2100-01-01T00:00:00.000Z'
 patch: {}


### PR DESCRIPTION
Add a new ignore for mongoose vulnerability as we rely on this repository ignoring everything inside registry