### PR TITLE
fix: Ignore new vuln in HTTPSPROXYAGENT

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -82,4 +82,8 @@ ignore:
     - snyk > @snyk/dep-graph > graphlib > lodash:
         reason: None given
         expires: '2100-01-01T00:00:00.000Z'
+  SNYK-JS-HTTPSPROXYAGENT-469131:
+    - '*':
+        reason: None Given
+        expires: 2019-11-01T13:40:50.129Z
 patch: {}


### PR DESCRIPTION
Do this to resolve total vulns again to 0 - which is expected by registry tests.