### PR TITLE
fix: ignore new mquery vulns

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -98,4 +98,8 @@ ignore:
     - mongoose > mongodb > mongodb-core > kerberos:
         reason: Fails tests on registry
         expires: '2100-06-12T06:54:14.888Z'
+  SNYK-JS-MQUERY-1050858:
+    - mongoose > mquery:
+        reason: Fails tests on registry
+        expires: '2100-06-12T06:54:14.888Z'
 patch: {}


### PR DESCRIPTION
New vuln failing registry test: `test/system/web/routes/test/test-report-2.spec.ts`

Vuln: http://app.snyk.io/test/github/snyk/shallow-goof-ignore-all#SNYK-JS-MQUERY-1050858